### PR TITLE
get chunk data using copyTo method instead of EncodedVideoChunk.data

### DIFF
--- a/src/extern-post.js
+++ b/src/extern-post.js
@@ -185,10 +185,14 @@ export function createWebCodecsEncoderWithModule(MP4, opts = {}) {
     }
 
     if (format === "annexb") {
-      nal.push(new Uint8Array(chunk.data));
+      const uint8 = new Uint8Array(chunk.byteLength);
+      chunk.copyTo(uint8);
+      nal.push(uint8);
     } else {
       try {
-        convertAVCToAnnexBInPlaceForLength4(chunk.data).forEach((sub) => {
+        const arrayBuf = new ArrayBuffer(chunk.byteLength);
+        chunk.copyTo(arrayBuf);
+        convertAVCToAnnexBInPlaceForLength4(arrayBuf).forEach((sub) => {
           nal.push(START_CODE);
           nal.push(sub);
         });


### PR DESCRIPTION
`data` property in `EncodedVideoChunk` is internal according to the [WebCodecs Spec](https://www.w3.org/TR/webcodecs/#encodedvideochunk-internal-slots) and is not exposed by newer versions of Chrome.

This may solve issue #3.

I didn't test about AVCC since my Chrome seems not generating standard AVCC data. But it works excellently for AnnexB format in Chrome Beta (94.0.4606.41).